### PR TITLE
extern crate no longer needed for Rust 2021

### DIFF
--- a/content/hexagonal-architecture-in-rust-3.md
+++ b/content/hexagonal-architecture-in-rust-3.md
@@ -60,8 +60,7 @@ mod api;
 mod domain;
 mod repositories;
 
-#[macro_use]
-extern crate rouille;
+use rouille::router;
 
 fn main() {
     api::serve("localhost:8000");
@@ -147,12 +146,6 @@ So let's go with:
 rouille = "3.2.1"
 serde = { version = "1.0.129", features = ["derive"] }
 serde_json = "1.0.66"
-```
-
-We'll also have to add the import in 'main.rs`:
-
-```
-extern crate serde;
 ```
 
 We are done with the dependencies! Now we can edit `api/health.rs`:


### PR DESCRIPTION
This is a debatable change, but it's probably safe to assume that
most people following the tutorial use Rust 2021 or newer.
In order to be future-proof, remove "extern crate" imports because
they are no longer needed in the Rust 2021 edition.
Instead, ordinary imports can be used, such as for `rouille::router`.